### PR TITLE
Fix exploit check for routers/linksys/test_eseries_themoon_rce.

### DIFF
--- a/routersploit/modules/exploits/routers/linksys/eseries_themoon_rce.py
+++ b/routersploit/modules/exploits/routers/linksys/eseries_themoon_rce.py
@@ -78,6 +78,22 @@ class Exploit(HTTPClient):
 
     @mute
     def check(self):
+        # See https://isc.sans.edu/diary/Linksys+Worm+%22TheMoon%22+Summary%3A+What+we+know+so+far/17633
+        response = self.http_request(
+            method="GET",
+            path="/HNAP1/",
+            headers={'Host': 'test'}
+        )
+
+        if not(response):
+            return False  # target is not vulnerable
+
+        content = response.content
+        if content and content.find(b'ModelName') == -1:
+            return False  # target is not vulnerable
+
+        # target may be vulnerable
+
         response = self.http_request(
             method="GET",
             path="/tmUnblock.cgi",

--- a/tests/exploits/routers/linksys/test_eseries_themoon_rce.py
+++ b/tests/exploits/routers/linksys/test_eseries_themoon_rce.py
@@ -6,6 +6,9 @@ from routersploit.modules.exploits.routers.linksys.eseries_themoon_rce import Ex
 def test_check_success(mocked_shell, target):
     """ Test scenario - successful check """
 
+    route_mock = target.get_route_mock("/HNAP1/", methods=["GET"])
+    route_mock.return_value = "<ModelName>E2500</ModelName>"
+
     route_mock = target.get_route_mock("/tmUnblock.cgi", methods=["GET", "POST"])
     route_mock.return_value = ""
 
@@ -15,3 +18,31 @@ def test_check_success(mocked_shell, target):
 
     assert exploit.check()
     assert exploit.run() is None
+
+
+@mock.patch("routersploit.modules.exploits.routers.linksys.eseries_themoon_rce.shell")
+def test_check_unsuccess_no_hnapi(mocked_shell, target):
+    """ Test scenario - unsuccessful check (no successful /HNAPI/ response)"""
+
+    route_mock = target.get_route_mock("/tmUnblock.cgi", methods=["GET", "POST"])
+    route_mock.return_value = ""
+
+    exploit = Exploit()
+    exploit.target = target.host
+    exploit.port = target.port
+
+    assert not(exploit.check())
+
+
+@mock.patch("routersploit.modules.exploits.routers.linksys.eseries_themoon_rce.shell")
+def test_check_success_no_cgi(mocked_shell, target):
+    """ Test scenario - unsuccessful check (no successful /tmUnblock.cgi response)"""
+
+    route_mock = target.get_route_mock("/HNAP1/", methods=["GET"])
+    route_mock.return_value = "<ModelName>E2500</ModelName>"
+
+    exploit = Exploit()
+    exploit.target = target.host
+    exploit.port = target.port
+
+    assert not(exploit.check())


### PR DESCRIPTION
## Status
**READY/IN DEVELOPMENT/HOLD**

## Description
Describe what is changed by your Pull Request. If this PR is related to the open issue (bug/feature/new module) please attach issue number.

## Verification
Provide steps to test or reproduce the PR.
 1. Start `./rsf.py`
 2. `use exploits/routers/dlink/dsl_2750b_rce`
 3. `set target 192.168.1.1`
 4. `run`
 5. ...

## Checklist
- [ ] Write module/feature 
- [ ] Write tests ([Example](https://github.com/threat9/routersploit/blob/master/tests/exploits/routers/dlink/test_dsl_2750b_rce.py))
- [ ] Document how it works ([Example](https://github.com/threat9/routersploit/blob/master/docs/modules/exploits/routers/dlink/dsl_2750b_rce.md))
